### PR TITLE
Fix warnings from automatic code inspections

### DIFF
--- a/bin/solaar
+++ b/bin/solaar
@@ -25,6 +25,7 @@ def init_paths():
     import sys
 
     # Python 3 might have problems converting back to UTF-8 in case of Unicode surrogates
+    decoded_path = None
     try:
         decoded_path = sys.path[0]
         sys.path[0].encode(sys.getfilesystemencoding())

--- a/lib/hid_parser/__init__.py
+++ b/lib/hid_parser/__init__.py
@@ -560,7 +560,8 @@ class ArrayItem(MainItem):
                 )
                 continue
 
-            if usage in self._usages and all(usage_type not in self._INCOMPATIBLE_TYPES for usage_type in usage.usage_types):
+            not_incompatible_type = all(usage_type not in self._INCOMPATIBLE_TYPES for usage_type in usage.usage_types)
+            if usage in self._usages and not_incompatible_type:
                 usage_values[usage] = UsageValue(self, True)
 
         return usage_values
@@ -820,14 +821,28 @@ class ReportDescriptor:
                     if data is None:
                         raise InvalidReportDescriptor("Invalid output item")
                     self._append_items(
-                        offset_output, self._output, report_id, report_count, report_size, usages, data, {**glob, **local}
+                        offset_output,
+                        self._output,
+                        report_id,
+                        report_count,
+                        report_size,
+                        usages,
+                        data,
+                        {**glob, **local},
                     )
 
                 elif tag == TagMain.FEATURE:
                     if data is None:
                         raise InvalidReportDescriptor("Invalid feature item")
                     self._append_items(
-                        offset_feature, self._feature, report_id, report_count, report_size, usages, data, {**glob, **local}
+                        offset_feature,
+                        self._feature,
+                        report_id,
+                        report_count,
+                        report_size,
+                        usages,
+                        data,
+                        {**glob, **local},
                     )
 
                 # clear local

--- a/lib/hidapi/common.py
+++ b/lib/hidapi/common.py
@@ -1,18 +1,20 @@
+from __future__ import annotations
+
 import dataclasses
 
 
 @dataclasses.dataclass
 class DeviceInfo:
     path: str
-    bus_id: str
+    bus_id: str | None
     vendor_id: str
     product_id: str
-    interface: str
-    driver: str
-    manufacturer: str
-    product: str
-    serial: str
-    release: str
+    interface: str | None
+    driver: str | None
+    manufacturer: str | None
+    product: str | None
+    serial: str | None
+    release: str | None
     isDevice: bool
-    hidpp_short: str
-    hidpp_long: str
+    hidpp_short: str | None
+    hidpp_long: str | None

--- a/lib/hidapi/hidapi_impl.py
+++ b/lib/hidapi/hidapi_impl.py
@@ -33,6 +33,7 @@ import typing
 
 from threading import Thread
 from time import sleep
+from typing import Callable
 
 from hidapi.common import DeviceInfo
 
@@ -203,6 +204,7 @@ class _DeviceMonitor(Thread):
     def __init__(self, device_callback, polling_delay=5.0):
         self.device_callback = device_callback
         self.polling_delay = polling_delay
+        self.prev_devices = None
         # daemon threads are automatically killed when main thread exits
         super().__init__(daemon=True)
 
@@ -259,7 +261,12 @@ def _match(action, device, filterfn):
 
     if logger.isEnabledFor(logging.INFO):
         logger.info(
-            "Found device BID %s VID %04X PID %04X HID++ %s %s", bus_id, vid, pid, device["hidpp_short"], device["hidpp_long"]
+            "Found device BID %s VID %04X PID %04X HID++ %s %s",
+            bus_id,
+            vid,
+            pid,
+            device["hidpp_short"],
+            device["hidpp_long"],
         )
 
     if not device["hidpp_short"] and not device["hidpp_long"]:
@@ -317,7 +324,7 @@ def find_paired_node_wpid(receiver_path: str, index: int):
     return None
 
 
-def monitor_glib(glib: GLib, callback, filterfn):
+def monitor_glib(glib: GLib, callback: Callable, filterfn: Callable):
     """Monitor GLib.
 
     Parameters
@@ -452,7 +459,6 @@ def read(device_handle, bytes_count, timeout_ms=None):
 
     if bytes_read < 0:
         raise HIDError(_hidapi.hid_error(device_handle))
-        return None
 
     return data.raw[:bytes_read]
 

--- a/lib/hidapi/udev_impl.py
+++ b/lib/hidapi/udev_impl.py
@@ -36,6 +36,7 @@ import warnings
 from select import select
 from time import sleep
 from time import time
+from typing import Callable
 
 import pyudev
 
@@ -114,7 +115,12 @@ def _match(action, device, filter_func: typing.Callable[[int, int, int, bool, bo
         hidpp_short = None
         hidpp_long = None
         logger.info(
-            "Report Descriptor not processed for DEVICE %s BID %s VID %s PID %s: %s", device.device_node, bid, vid, pid, e
+            "Report Descriptor not processed for DEVICE %s BID %s VID %s PID %s: %s",
+            device.device_node,
+            bid,
+            vid,
+            pid,
+            e,
         )
 
     filtered_result = filter_func(int(bid, 16), int(vid, 16), int(pid, 16), hidpp_short, hidpp_long)
@@ -222,7 +228,7 @@ def find_paired_node_wpid(receiver_path, index):
     return None
 
 
-def monitor_glib(glib: GLib, callback, filterfn):
+def monitor_glib(glib: GLib, callback: Callable, filterfn: typing.Callable):
     """Monitor GLib.
 
     Parameters
@@ -453,7 +459,7 @@ def get_indexed_string(device_handle, index):
     assert device_handle
     stat = os.fstat(device_handle)
     try:
-        dev = pyudev.Device.from_device_number(pyudev.Context(), "char", stat.st_rdev)
+        dev = pyudev.Devices.from_device_number(pyudev.Context(), "char", stat.st_rdev)
     except (pyudev.DeviceNotFoundError, ValueError):
         return None
 

--- a/lib/logitech_receiver/common.py
+++ b/lib/logitech_receiver/common.py
@@ -370,12 +370,12 @@ class NamedInts:
 
     __slots__ = ("__dict__", "_values", "_indexed", "_fallback", "_is_sorted")
 
-    def __init__(self, dict=None, **kwargs):
+    def __init__(self, dict_=None, **kwargs):
         def _readable_name(n):
             return n.replace("__", "/").replace("_", " ")
 
         # print (repr(kwargs))
-        elements = dict if dict else kwargs
+        elements = dict_ if dict_ else kwargs
         values = {k: NamedInt(v, _readable_name(k)) for (k, v) in elements.items()}
         self.__dict__ = values
         self._is_sorted = False
@@ -499,7 +499,7 @@ class NamedInts:
         return NamedInts(**self.__dict__, **other.__dict__)
 
     def __eq__(self, other):
-        return type(self) == type(other) and self._values == other._values
+        return isinstance(other, self.__class__) and self._values == other._values
 
 
 class UnsortedNamedInts(NamedInts):
@@ -548,7 +548,7 @@ class FirmwareInfo:
     kind: str
     name: str
     version: str
-    extras: str
+    extras: str | None
 
 
 class BatteryStatus(IntEnum):

--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -225,7 +225,13 @@ _D("Craft Advanced Keyboard", codename="Craft", protocol=4.5, wpid="4066", btid=
 _D("Wireless Illuminated Keyboard K800 new", codename="K800 new", protocol=4.5, wpid="406E")
 _D("Wireless Keyboard K470", codename="K470", protocol=4.5, wpid="4075")
 _D("MX Keys Keyboard", codename="MX Keys", protocol=4.5, wpid="408A", btid=0xB35B)
-_D("G915 TKL LIGHTSPEED Wireless RGB Mechanical Gaming Keyboard", codename="G915 TKL", protocol=4.2, wpid="408E", usbid=0xC343)
+_D(
+    "G915 TKL LIGHTSPEED Wireless RGB Mechanical Gaming Keyboard",
+    codename="G915 TKL",
+    protocol=4.2,
+    wpid="408E",
+    usbid=0xC343,
+)
 _D("Illuminated Keyboard", codename="Illuminated", protocol=1.0, usbid=0xC318, interface=1)
 _D("G213 Prodigy Gaming Keyboard", codename="G213", usbid=0xC336, interface=1)
 _D("G512 RGB Mechanical Gaming Keyboard", codename="G512", usbid=0xC33C, interface=1)
@@ -253,7 +259,14 @@ _D(
     wpid=("1006", "100D", "0612"),
     registers=(Reg.BATTERY_CHARGE,),
 )
-_D("MX Air", codename="MX Air", protocol=1.0, kind=DEVICE_KIND.mouse, wpid=("1007", "100E"), registers=(Reg.BATTERY_CHARGE))
+_D(
+    "MX Air",
+    codename="MX Air",
+    protocol=1.0,
+    kind=DEVICE_KIND.mouse,
+    wpid=("1007", "100E"),
+    registers=Reg.BATTERY_CHARGE,
+)
 _D(
     "MX Revolution",
     codename="MX Revolution",
@@ -262,10 +275,34 @@ _D(
     wpid=("1008", "100C"),
     registers=(Reg.BATTERY_CHARGE,),
 )
-_D("MX620 Laser Cordless Mouse", codename="MX620", protocol=1.0, wpid=("100A", "1016"), registers=(Reg.BATTERY_CHARGE,))
-_D("VX Nano Cordless Laser Mouse", codename="VX Nano", protocol=1.0, wpid=("100B", "100F"), registers=(Reg.BATTERY_CHARGE,))
-_D("V450 Nano Cordless Laser Mouse", codename="V450 Nano", protocol=1.0, wpid="1011", registers=(Reg.BATTERY_CHARGE,))
-_D("V550 Nano Cordless Laser Mouse", codename="V550 Nano", protocol=1.0, wpid="1013", registers=(Reg.BATTERY_CHARGE,))
+_D(
+    "MX620 Laser Cordless Mouse",
+    codename="MX620",
+    protocol=1.0,
+    wpid=("100A", "1016"),
+    registers=(Reg.BATTERY_CHARGE,),
+)
+_D(
+    "VX Nano Cordless Laser Mouse",
+    codename="VX Nano",
+    protocol=1.0,
+    wpid=("100B", "100F"),
+    registers=(Reg.BATTERY_CHARGE,),
+)
+_D(
+    "V450 Nano Cordless Laser Mouse",
+    codename="V450 Nano",
+    protocol=1.0,
+    wpid="1011",
+    registers=(Reg.BATTERY_CHARGE,),
+)
+_D(
+    "V550 Nano Cordless Laser Mouse",
+    codename="V550 Nano",
+    protocol=1.0,
+    wpid="1013",
+    registers=(Reg.BATTERY_CHARGE,),
+)
 _D(
     "MX 1100 Cordless Laser Mouse",
     codename="MX 1100",
@@ -282,11 +319,40 @@ _D(
     wpid="101A",
     registers=(Reg.BATTERY_STATUS, Reg.THREE_LEDS),
 )
-_D("Marathon Mouse M705 (M-R0009)", codename="M705 (M-R0009)", protocol=1.0, wpid="101B", registers=(Reg.BATTERY_CHARGE,))
-_D("Wireless Mouse M350", codename="M350", protocol=1.0, wpid="101C", registers=(Reg.BATTERY_CHARGE,))
-_D("Wireless Mouse M505", codename="M505/B605", protocol=1.0, wpid="101D", registers=(Reg.BATTERY_CHARGE,))
-_D("Wireless Mouse M305", codename="M305", protocol=1.0, wpid="101F", registers=(Reg.BATTERY_STATUS,))
-_D("Wireless Mouse M215", codename="M215", protocol=1.0, wpid="1020")
+_D(
+    "Marathon Mouse M705 (M-R0009)",
+    codename="M705 (M-R0009)",
+    protocol=1.0,
+    wpid="101B",
+    registers=(Reg.BATTERY_CHARGE,),
+)
+_D(
+    "Wireless Mouse M350",
+    codename="M350",
+    protocol=1.0,
+    wpid="101C",
+    registers=(Reg.BATTERY_CHARGE,),
+)
+_D(
+    "Wireless Mouse M505",
+    codename="M505/B605",
+    protocol=1.0,
+    wpid="101D",
+    registers=(Reg.BATTERY_CHARGE,),
+)
+_D(
+    "Wireless Mouse M305",
+    codename="M305",
+    protocol=1.0,
+    wpid="101F",
+    registers=(Reg.BATTERY_STATUS,),
+)
+_D(
+    "Wireless Mouse M215",
+    codename="M215",
+    protocol=1.0,
+    wpid="1020",
+)
 _D(
     "G700 Gaming Mouse",
     codename="G700",
@@ -382,5 +448,19 @@ _D("G533 Gaming Headset", codename="G533 Headset", protocol=2.0, interface=3, ki
 _D("G535 Gaming Headset", codename="G535 Headset", protocol=2.0, interface=3, kind=DEVICE_KIND.headset, usbid=0x0AC4)
 _D("G935 Gaming Headset", codename="G935 Headset", protocol=2.0, interface=3, kind=DEVICE_KIND.headset, usbid=0x0A87)
 _D("G733 Gaming Headset", codename="G733 Headset", protocol=2.0, interface=3, kind=DEVICE_KIND.headset, usbid=0x0AB5)
-_D("G733 Gaming Headset", codename="G733 Headset New", protocol=2.0, interface=3, kind=DEVICE_KIND.headset, usbid=0x0AFE)
-_D("PRO X Wireless Gaming Headset", codename="PRO Headset", protocol=2.0, interface=3, kind=DEVICE_KIND.headset, usbid=0x0ABA)
+_D(
+    "G733 Gaming Headset",
+    codename="G733 Headset New",
+    protocol=2.0,
+    interface=3,
+    kind=DEVICE_KIND.headset,
+    usbid=0x0AFE,
+)
+_D(
+    "PRO X Wireless Gaming Headset",
+    codename="PRO Headset",
+    protocol=2.0,
+    interface=3,
+    kind=DEVICE_KIND.headset,
+    usbid=0x0ABA,
+)

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -176,7 +176,11 @@ class Device:
                 descriptors.get_btid(self.product_id) if self.bluetooth else descriptors.get_usbid(self.product_id)
             )
             if self.number is None:  # for direct-connected devices get 'number' from descriptor protocol else use 0xFF
-                self.number = 0x00 if self.descriptor and self.descriptor.protocol and self.descriptor.protocol < 2.0 else 0xFF
+                if self.descriptor and self.descriptor.protocol and self.descriptor.protocol < 2.0:
+                    number = 0x00
+                else:
+                    number = 0xFF
+                self.number = number
             self.ping()  # determine whether a direct-connected device is online
 
         if self.descriptor:

--- a/lib/logitech_receiver/hidpp20_constants.py
+++ b/lib/logitech_receiver/hidpp20_constants.py
@@ -150,7 +150,14 @@ FEATURE._fallback = lambda x: f"unknown:{x:04X}"
 FEATURE_FLAG = NamedInts(internal=0x20, hidden=0x40, obsolete=0x80)
 
 DEVICE_KIND = NamedInts(
-    keyboard=0x00, remote_control=0x01, numpad=0x02, mouse=0x03, touchpad=0x04, trackball=0x05, presenter=0x06, receiver=0x07
+    keyboard=0x00,
+    remote_control=0x01,
+    numpad=0x02,
+    mouse=0x03,
+    touchpad=0x04,
+    trackball=0x05,
+    presenter=0x06,
+    receiver=0x07,
 )
 
 FIRMWARE_KIND = NamedInts(Firmware=0x00, Bootloader=0x01, Hardware=0x02, Other=0x03)

--- a/lib/logitech_receiver/settings.py
+++ b/lib/logitech_receiver/settings.py
@@ -111,7 +111,7 @@ class Setting:
         assert hasattr(self, "_device")
 
         if self._validator.kind == KIND.range:
-            return (self._validator.min_value, self._validator.max_value)
+            return self._validator.min_value, self._validator.max_value
 
     def _pre_read(self, cached, key=None):
         if self.persist and self._value is None and getattr(self._device, "persister", None):
@@ -1208,7 +1208,7 @@ class RangeValidator(Validator):
         if len(args) == 1:
             return args[0] == current
         elif len(args) == 2:
-            return args[0] <= current and current <= args[1]
+            return args[0] <= current <= args[1]
         else:
             return False
 

--- a/lib/solaar/__init__.py
+++ b/lib/solaar/__init__.py
@@ -22,7 +22,17 @@ NAME = "Solaar"
 
 try:
     __version__ = (
-        subprocess.check_output(["git", "describe", "--always"], cwd=sys.path[0], stderr=subprocess.DEVNULL).strip().decode()
+        subprocess.check_output(
+            [
+                "git",
+                "describe",
+                "--always",
+            ],
+            cwd=sys.path[0],
+            stderr=subprocess.DEVNULL,
+        )
+        .strip()
+        .decode()
     )
 except Exception:
     try:

--- a/lib/solaar/cli/__init__.py
+++ b/lib/solaar/cli/__init__.py
@@ -33,7 +33,9 @@ logger = logging.getLogger(__name__)
 
 def _create_parser():
     parser = argparse.ArgumentParser(
-        prog=NAME.lower(), add_help=False, epilog=f"For details on individual actions, run `{NAME.lower()} <action> --help`."
+        prog=NAME.lower(),
+        add_help=False,
+        epilog=f"For details on individual actions, run `{NAME.lower()} <action> --help`.",
     )
     subparsers = parser.add_subparsers(title="actions", help="command-line action to perform")
 
@@ -53,7 +55,11 @@ def _create_parser():
     )
     sp.set_defaults(action="probe")
 
-    sp = subparsers.add_parser("profiles", help="read or write onboard profiles", epilog="Only works on active devices.")
+    sp = subparsers.add_parser(
+        "profiles",
+        help="read or write onboard profiles",
+        epilog="Only works on active devices.",
+    )
     sp.add_argument(
         "device",
         help="device to read or write profiles of; may be a device number (1..6), a serial number, "
@@ -69,7 +75,10 @@ def _create_parser():
     )
     sp.add_argument(
         "device",
-        help="device to configure; may be a device number (1..6), a serial number, " "or a substring of a device's name",
+        help=(
+            "device to configure; may be a device number (1..6), a serial number, ",
+            "or a substring of a device's name",
+        ),
     )
     sp.add_argument("setting", nargs="?", help="device-specific setting; leave empty to list available settings")
     sp.add_argument("value_key", nargs="?", help="new value for the setting or key for keyed settings")
@@ -206,7 +215,7 @@ def run(cli_args=None, hidraw_path=None):
             c = list(_receivers(hidraw_path))
         if not c:
             raise Exception(
-                'No supported device found.  Use "lsusb" and "bluetoothctl devices Connected" to list connected devices.'
+                'No supported device found. Use "lsusb" and "bluetoothctl devices Connected" to list connected devices.'
             )
         m = import_module("." + action, package=__name__)
         m.run(c, args, _find_receiver, _find_device)

--- a/lib/solaar/cli/config.py
+++ b/lib/solaar/cli/config.py
@@ -22,6 +22,8 @@ from logitech_receiver.common import NamedInts
 
 from solaar import configuration
 
+APP_ID = "io.github.pwr_solaar.solaar"
+
 
 def _print_setting(s, verbose=True):
     print("#", s.label)
@@ -92,7 +94,7 @@ def select_choice(value, choices, setting, key):
             break
     if val is not None:
         value = val
-    elif ivalue is not None and ivalue >= 1 and ivalue <= len(choices):
+    elif ivalue is not None and 1 <= ivalue <= len(choices):
         value = choices[ivalue - 1]
     elif lvalue in ("higher", "lower"):
         old_value = setting.read() if key is None else setting.read_key(key)
@@ -134,13 +136,13 @@ def select_range(value, setting):
         value = int(value)
     except ValueError as exc:
         raise Exception(f"{setting.name}: can't interpret '{value}' as integer") from exc
-    min, max = setting.range
-    if value < min or value > max:
+    minimum, maximum = setting.range
+    if value < minimum or value > maximum:
         raise Exception(f"{setting.name}: value '{value}' out of bounds")
     return value
 
 
-def run(receivers, args, find_receiver, find_device):
+def run(receivers, args, _find_receiver, find_device):
     assert receivers
     assert args.device
 
@@ -190,7 +192,6 @@ def run(receivers, args, find_receiver, find_device):
         from gi.repository import Gtk
 
         if Gtk.init_check()[0]:  # can Gtk be initialized?
-            APP_ID = "io.github.pwr_solaar.solaar"
             application = Gtk.Application.new(APP_ID, Gio.ApplicationFlags.HANDLES_COMMAND_LINE)
             application.register()
             remote = application.get_is_remote()
@@ -236,7 +237,7 @@ def set(dev, setting, args, save):
     elif setting.kind == settings.KIND.map_choice:
         if args.extra_subkey is None:
             _print_setting_keyed(setting, args.value_key)
-            return (None, None, None)
+            return None, None, None
         key = args.value_key
         ikey = to_int(key)
         k = next((k for k in setting.choices.keys() if key == k), None)
@@ -254,7 +255,7 @@ def set(dev, setting, args, save):
     elif setting.kind == settings.KIND.multiple_toggle:
         if args.extra_subkey is None:
             _print_setting_keyed(setting, args.value_key)
-            return (None, None, None)
+            return None, None, None
         key = args.value_key
         all_keys = getattr(setting, "choices_universe", None)
         ikey = all_keys[int(key) if key.isdigit() else key] if isinstance(all_keys, NamedInts) else to_int(key)

--- a/lib/solaar/cli/pair.py
+++ b/lib/solaar/cli/pair.py
@@ -51,7 +51,7 @@ def run(receivers, args, find_receiver, _ignore):
             assert n
             if n.devnumber == 0xFF:
                 notifications.process(receiver, n)
-            elif n.sub_id == 0x41 and len(n.data) == base._SHORT_MESSAGE_SIZE - 4:
+            elif n.sub_id == 0x41 and len(n.data) == base.SHORT_MESSAGE_SIZE - 4:
                 kd, known_devices = known_devices, None  # only process one connection notification
                 if kd is not None:
                     if n.devnumber not in kd:

--- a/lib/solaar/gtk.py
+++ b/lib/solaar/gtk.py
@@ -50,6 +50,7 @@ def _require(module, os_package, gi=None, gi_package=None, gi_version=None):
 
 
 battery_icons_style = "regular"
+tray_icon_size = None
 temp = tempfile.NamedTemporaryFile(prefix="Solaar_", mode="w", delete=True)
 
 
@@ -72,9 +73,16 @@ def _parse_arguments():
         metavar="PATH",
         help="unifying receiver to use; the first detected receiver if unspecified. Example: /dev/hidraw2",
     )
-    arg_parser.add_argument("--restart-on-wake-up", action="store_true", help="restart Solaar on sleep wake-up (experimental)")
     arg_parser.add_argument(
-        "-w", "--window", choices=("show", "hide", "only"), help="start with window showing / hidden / only (no tray icon)"
+        "--restart-on-wake-up",
+        action="store_true",
+        help="restart Solaar on sleep wake-up (experimental)",
+    )
+    arg_parser.add_argument(
+        "-w",
+        "--window",
+        choices=("show", "hide", "only"),
+        help="start with window showing / hidden / only (no tray icon)",
     )
     arg_parser.add_argument(
         "-b",

--- a/lib/solaar/listener.py
+++ b/lib/solaar/listener.py
@@ -49,7 +49,13 @@ _GHOST_DEVICE.__nonzero__ = _GHOST_DEVICE.__bool__
 
 
 def _ghost(device):
-    return _GHOST_DEVICE(receiver=device.receiver, number=device.number, name=device.name, kind=device.kind, online=False)
+    return _GHOST_DEVICE(
+        receiver=device.receiver,
+        number=device.number,
+        name=device.name,
+        kind=device.kind,
+        online=False,
+    )
 
 
 class SolaarListener(listener.EventsListener):
@@ -230,7 +236,9 @@ class SolaarListener(listener.EventsListener):
 
 
 def _process_bluez_dbus(device, path, dictionary, signature):
-    """Process bluez dbus property changed signals for device status changes to discover disconnections and connections"""
+    """Process bluez dbus property changed signals for device status
+    changes to discover disconnections and connections.
+    """
     if device:
         if dictionary.get("Connected") is not None:
             connected = dictionary.get("Connected")

--- a/lib/solaar/ui/__init__.py
+++ b/lib/solaar/ui/__init__.py
@@ -84,7 +84,7 @@ def _command_line(app, command_line):
     return 0
 
 
-def _shutdown(app, shutdown_hook):
+def _shutdown(_app, shutdown_hook):
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug("shutdown")
     shutdown_hook()

--- a/lib/solaar/ui/about/presenter.py
+++ b/lib/solaar/ui/about/presenter.py
@@ -31,7 +31,7 @@ class AboutViewProtocol(Protocol):
     def update_description(self, comments: str) -> None:
         ...
 
-    def update_copyright(self, copyright):
+    def update_copyright(self, copyright_text: str) -> None:
         ...
 
     def update_authors(self, authors: list[str]) -> None:
@@ -68,8 +68,8 @@ class Presenter:
         self.view.update_description(comments)
 
     def update_copyright(self) -> None:
-        copyright = self.model.get_copyright()
-        self.view.update_copyright(copyright)
+        copyright_text = self.model.get_copyright()
+        self.view.update_copyright(copyright_text)
 
     def update_authors(self) -> None:
         authors = self.model.get_authors()

--- a/lib/solaar/ui/common.py
+++ b/lib/solaar/ui/common.py
@@ -48,7 +48,10 @@ def _create_error_text(reason: str, object_) -> Tuple[str, str]:
     elif reason == "unpair":
         title = _("Unpairing failed")
         text = (
-            _("Failed to unpair %{device} from %{receiver}.").format(device=object_.name, receiver=object_.receiver.name)
+            _("Failed to unpair %{device} from %{receiver}.").format(
+                device=object_.name,
+                receiver=object_.receiver.name,
+            )
             + "\n\n"
             + _("The receiver returned an error, with no further details.")
         )

--- a/lib/solaar/ui/pair_window.py
+++ b/lib/solaar/ui/pair_window.py
@@ -156,13 +156,21 @@ def _show_passcode(assistant, receiver, passkey):
     page_text = _("Enter passcode on %(name)s.") % {"name": name}
     page_text += "\n"
     if authentication & 0x01:
-        page_text += _("Type %(passcode)s and then press the enter key.") % {"passcode": receiver.pairing.device_passkey}
+        page_text += _("Type %(passcode)s and then press the enter key.") % {
+            "passcode": receiver.pairing.device_passkey,
+        }
     else:
         passcode = ", ".join(
             [_("right") if bit == "1" else _("left") for bit in f"{int(receiver.pairing.device_passkey):010b}"]
         )
         page_text += _("Press %(code)s\nand then press left and right buttons simultaneously.") % {"code": passcode}
-    page = _create_page(assistant, Gtk.AssistantPageType.PROGRESS, intro_text, "preferences-desktop-peripherals", page_text)
+    page = _create_page(
+        assistant,
+        Gtk.AssistantPageType.PROGRESS,
+        intro_text,
+        "preferences-desktop-peripherals",
+        page_text,
+    )
     assistant.set_page_complete(page, True)
     assistant.next_page()
 
@@ -175,7 +183,13 @@ def _create_assistant(receiver, ok, finish, title, text):
     assistant.set_resizable(False)
     assistant.set_role("pair-device")
     if ok:
-        page_intro = _create_page(assistant, Gtk.AssistantPageType.PROGRESS, title, "preferences-desktop-peripherals", text)
+        page_intro = _create_page(
+            assistant,
+            Gtk.AssistantPageType.PROGRESS,
+            title,
+            "preferences-desktop-peripherals",
+            text,
+        )
         spinner = Gtk.Spinner()
         spinner.set_visible(True)
         spinner.start()
@@ -217,7 +231,7 @@ def _create_success_page(assistant, device):
     assistant.commit()
 
 
-def _create_failure_page(assistant, error):
+def _create_failure_page(assistant, error) -> None:
     header = _("Pairing failed") + ": " + _(str(error)) + "."
     if "timeout" in str(error):
         text = _("Make sure your device is within range, and has a decent battery charge.")
@@ -232,7 +246,7 @@ def _create_failure_page(assistant, error):
     assistant.commit()
 
 
-def _create_page(assistant, kind, header=None, icon_name=None, text=None):
+def _create_page(assistant, kind, header=None, icon_name=None, text=None) -> Gtk.VBox:
     p = Gtk.VBox(homogeneous=False, spacing=8)
     assistant.append_page(p)
     assistant.set_page_type(p, kind)

--- a/lib/solaar/ui/rule_base.py
+++ b/lib/solaar/ui/rule_base.py
@@ -15,6 +15,7 @@
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from contextlib import contextmanager as contextlib_contextmanager
+from typing import Callable
 
 from gi.repository import Gtk
 from logitech_receiver import diversion
@@ -49,7 +50,7 @@ class CompletionEntry(Gtk.Entry):
 class RuleComponentUI:
     CLASS = diversion.RuleComponent
 
-    def __init__(self, panel, on_update=None):
+    def __init__(self, panel, on_update: Callable = None):
         self.panel = panel
         self.widgets = {}  # widget -> coord. in grid
         self.component = None

--- a/lib/solaar/ui/tray.py
+++ b/lib/solaar/ui/tray.py
@@ -72,7 +72,8 @@ def _scroll(tray_icon, event, direction=None):
         # ignore all other directions
         return
 
-    if sum(map(lambda i: i[1] is not None, _devices_info)) < 2:  # don't bother even trying to scroll if less than two devices
+    # don't bother even trying to scroll if less than two devices
+    if sum(map(lambda i: i[1] is not None, _devices_info)) < 2:
         return
 
     # scroll events come way too fast (at least 5-6 at once) so take a little break between them
@@ -215,7 +216,10 @@ except ImportError:
         icon.set_tooltip_text(NAME)
         icon.connect("activate", window.toggle)
         icon.connect("scroll-event", _scroll)
-        icon.connect("popup-menu", lambda icon, button, time: menu.popup(None, None, icon.position_menu, icon, button, time))
+        icon.connect(
+            "popup-menu",
+            lambda icon, button, time: menu.popup(None, None, icon.position_menu, icon, button, time),
+        )
 
         return icon
 

--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -501,47 +501,47 @@ def _update_details(button):
             # If read_all is False, only return stuff that is ~100% already
             # cached, and involves no HID++ calls.
 
-            yield (_("Path"), device.path)
+            yield _("Path"), device.path
             if device.kind is None:
-                yield (_("USB ID"), f"{LOGITECH_VENDOR_ID:04x}:" + device.product_id)
+                yield _("USB ID"), f"{LOGITECH_VENDOR_ID:04x}:" + device.product_id
 
                 if read_all:
-                    yield (_("Serial"), device.serial)
+                    yield _("Serial"), device.serial
                 else:
-                    yield (_("Serial"), "...")
+                    yield _("Serial"), "..."
 
             else:
                 # yield ('Codename', device.codename)
-                yield (_("Index"), device.number)
+                yield _("Index"), device.number
                 if device.wpid:
-                    yield (_("Wireless PID"), device.wpid)
+                    yield _("Wireless PID"), device.wpid
                 if device.product_id:
-                    yield (_("Product ID"), f"{LOGITECH_VENDOR_ID:04x}:" + device.product_id)
+                    yield _("Product ID"), f"{LOGITECH_VENDOR_ID:04x}:" + device.product_id
                 hid_version = device.protocol
-                yield (_("Protocol"), f"HID++ {hid_version:1.1f}" if hid_version else _("Unknown"))
+                yield _("Protocol"), f"HID++ {hid_version:1.1f}" if hid_version else _("Unknown")
                 if read_all and device.polling_rate:
-                    yield (_("Polling rate"), device.polling_rate)
+                    yield _("Polling rate"), device.polling_rate
 
                 if read_all or not device.online:
-                    yield (_("Serial"), device.serial)
+                    yield _("Serial"), device.serial
                 else:
-                    yield (_("Serial"), "...")
+                    yield _("Serial"), "..."
                 if read_all and device.unitId and device.unitId != device.serial:
-                    yield (_("Unit ID"), device.unitId)
+                    yield _("Unit ID"), device.unitId
 
             if read_all:
                 if device.firmware:
                     for fw in list(device.firmware):
-                        yield ("  " + _(str(fw.kind)), (fw.name + " " + fw.version).strip())
+                        yield "  " + _(str(fw.kind)), (fw.name + " " + fw.version).strip()
             elif device.kind is None or device.online:
-                yield (f"  {_('Firmware')}", "...")
+                yield f"  {_('Firmware')}", "..."
 
             flag_bits = device.notification_flags
             if flag_bits is not None:
                 flag_names = (
                     (f"({_('none')})",) if flag_bits == 0 else hidpp10_constants.NOTIFICATION_FLAG.flag_names(flag_bits)
                 )
-                yield (_("Notifications"), (f"\n{' ':15}").join(flag_names))
+                yield _("Notifications"), f"\n{' ':15}".join(flag_names)
 
         def _set_details(text):
             _details._text.set_markup(text)

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,7 @@ from os.path import dirname
 from pathlib import Path
 
 from setuptools import find_packages
-
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
 NAME = "Solaar"
 version = Path("lib/solaar/version").read_text().strip()

--- a/tests/logitech_receiver/fake_hidpp.py
+++ b/tests/logitech_receiver/fake_hidpp.py
@@ -16,6 +16,7 @@
 
 """HID++ data and functions common to several logitech_receiver test files"""
 
+from __future__ import annotations
 
 import errno
 import threading
@@ -43,7 +44,17 @@ def ping(responses, handle, devnumber, long_message=False):
             return r.response
 
 
-def request(responses, handle, devnumber, id, *params, no_reply=False, return_error=False, long_message=False, protocol=1.0):
+def request(
+    responses,
+    handle,
+    devnumber,
+    id,
+    *params,
+    no_reply=False,
+    return_error=False,
+    long_message=False,
+    protocol=1.0,
+):
     params = b"".join(pack("B", p) if isinstance(p, int) else p for p in params)
     print("REQUEST ", hex(handle), hex(devnumber), hex(id), params.hex())
     for r in responses:
@@ -54,7 +65,7 @@ def request(responses, handle, devnumber, id, *params, no_reply=False, return_er
 
 @dataclass
 class Response:
-    response: Optional[str]
+    response: str | float
     id: int
     params: str = ""
     handle: int = 0x11

--- a/tests/logitech_receiver/test_hidpp10.py
+++ b/tests/logitech_receiver/test_hidpp10.py
@@ -225,7 +225,7 @@ def test_set_3leds(device, level, charging, warning, p1, p2, mocker):
     spy_request.assert_called_once_with(0x8000 | Registers.THREE_LEDS, p1, p2)
 
 
-@pytest.mark.parametrize("device", [(device_offline), (device_features)])
+@pytest.mark.parametrize("device", [device_offline, device_features])
 def test_set_3leds_missing(device, mocker):
     spy_request = mocker.spy(device, "request")
 

--- a/tests/logitech_receiver/test_hidpp20_complex.py
+++ b/tests/logitech_receiver/test_hidpp20_complex.py
@@ -288,9 +288,12 @@ def test_ReprogrammableKeyV4_set(responses, index, diverted, persistently_divert
         (fake_hidpp.responses_key, 3, 0x0053, 0x02, 0x0001, 0x00, 1, "Mouse Button: 1", "", "02000100", "7FFFFFFF"),
     ],
 )
-def test_RemappableAction(r, index, cid, actionId, remapped, mask, status, action, modifiers, byts, remap, mocker):
+def test_remappable_action(r, index, cid, actionId, remapped, mask, status, action, modifiers, byts, remap, mocker):
     if int(remap, 16) == special_keys.KEYS_Default:
-        responses = r + [fake_hidpp.Response("040000", 0x0000, "1C00"), fake_hidpp.Response("00", 0x450, f"{cid:04X}" + "FF")]
+        responses = r + [
+            fake_hidpp.Response("040000", 0x0000, "1C00"),
+            fake_hidpp.Response("00", 0x450, f"{cid:04X}" + "FF"),
+        ]
     else:
         responses = r + [
             fake_hidpp.Response("040000", 0x0000, "1C00"),


### PR DESCRIPTION
Warnings found by automatic code inspection and partially tackled
- Drop distuitls inf favour of setuptools
- Replace deprecated pyudev.Device.from_device_number
- Remove unnecessary brackets
- Avoid access to private variables etc.
- Shadows built-in name
- Line length >120 characters
- Not a module level variable
- Simplify clause and more